### PR TITLE
The delay helper has been removed in recent Mojolicious versions.

### DIFF
--- a/lib/Mojolicious/Plugin/ACME.pm
+++ b/lib/Mojolicious/Plugin/ACME.pm
@@ -44,7 +44,7 @@ sub register {
     my $token = $c->stash('token');
     my $secret = $c->app->secrets->[0];
     my $hmac = hmac_sha1_sum $token, $secret;
-    $c->delay(
+    Mojo::IOLoop->delay(
       sub { $ua->get($url->clone->path("/$token"), {'X-HMAC' => $hmac}, shift->begin) },
       sub {
         my ($delay, $tx) = @_;


### PR DESCRIPTION
Change it to Mojo::IOLoop->delay.
Tested.
Works.
Best regards
Franz Skale